### PR TITLE
Fix language option in mkv_lang_switch script

### DIFF
--- a/mkv_lang_switch.sh
+++ b/mkv_lang_switch.sh
@@ -25,7 +25,7 @@ find "$1" -type f -name '*.mkv' -print0 | while IFS= read -r -d '' file; do
         --edit track:$id \
         --set name="Tamil" \
         --set language=tam \
-        --set languageIETF=ta
+        --set language-ietf=ta
     done
     echo "$(basename "$file")" >> "$processed_file"
   fi


### PR DESCRIPTION
## Summary
- use correct `mkvpropedit` option `language-ietf`

## Testing
- `bash mkv_lang_switch.sh /tmp` *(fails: cannot touch `/home/pbu80/logs/.mkv_language_fixed`)*

------
https://chatgpt.com/codex/tasks/task_e_6889dda0da608329b380cb0792d4dcd1