### PR TITLE
Add flexible language options to mkv_lang_switch script

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ Creates a folder for each MKV/MP4 file based on its name (up to the first closin
 bash movie2folder.sh /path/to/folder
 ```
 
+### `mkv_lang_switch.sh`
+Updates the language tags for every audio track in MKV files to a specified language and forces all subtitle tracks to English.  Supports predefined options such as `--tamil`, `--hindi`, `--english`, `--telugu`, `--malayalam` or a `--custom` name/language/language‑ietf combination.
+
+```bash
+bash mkv_lang_switch.sh /path/to/folder --tamil
+```
+
 ## Notes
 
 Several scripts call helper utilities not present in this repository (e.g. `convert_720p.sh`, `unrar.sh`, `trimvideo.sh`).  Ensure those exist on your system or adjust the scripts accordingly.

--- a/mkv_lang_switch.sh
+++ b/mkv_lang_switch.sh
@@ -1,32 +1,102 @@
 #!/bin/bash
 
-# This script updates tracks with English language tags to Tamil.
-# Usage: mkv_lang_switch.sh /path/to/folder
+# This script updates audio track language tags to a specified language and
+# forces all subtitle tracks to English.
+# Usage:
+#   mkv_lang_switch.sh /path/to/folder --tamil
+#   mkv_lang_switch.sh /path/to/folder --custom "Name" lang ietf
 
-if [ $# -eq 0 ]; then
-  echo "No folder path provided. Please provide a folder path as an argument."
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 /path/to/folder [--tamil|--hindi|--english|--telugu|--malayalam|--custom Name lang ietf]"
   exit 1
 fi
+
+folder="$1"
+option="$2"
+
+case "$option" in
+  --tamil)
+    track_name="Tamil"
+    lang="tam"
+    lang_ietf="ta"
+    ;;
+  --hindi)
+    track_name="Hindi"
+    lang="hin"
+    lang_ietf="hi"
+    ;;
+  --english)
+    track_name="English"
+    lang="eng"
+    lang_ietf="en"
+    ;;
+  --telugu)
+    track_name="Telugu"
+    lang="tel"
+    lang_ietf="te"
+    ;;
+  --malayalam)
+    track_name="Malayalam"
+    lang="mal"
+    lang_ietf="ml"
+    ;;
+  --custom)
+    if [ $# -ne 5 ]; then
+      echo "Usage: $0 /path/to/folder --custom \"Name\" lang ietf"
+      exit 1
+    fi
+    track_name="$3"
+    lang="$4"
+    lang_ietf="$5"
+    ;;
+  *)
+    echo "Unknown language option: $option"
+    exit 1
+    ;;
+esac
 
 # Log processed files
 processed_file="/home/pbu80/logs/.mkv_language_fixed"
 touch "$processed_file"
 
-find "$1" -type f -name '*.mkv' -print0 | while IFS= read -r -d '' file; do
+find "$folder" -type f -name '*.mkv' -print0 | while IFS= read -r -d '' file; do
   echo "Processing $file..."
 
-  # Retrieve track IDs that use English language settings
-  eng_tracks=$(mkvmerge -J "$file" 2>/dev/null |
-    jq -r '.tracks[] | select(.properties.language == "eng" or .properties.language_ietf == "en" or .properties.language == "English") | .id')
+  tracks_json=$(mkvmerge -J "$file" 2>/dev/null)
 
-  if [ -n "$eng_tracks" ]; then
-    for id in $eng_tracks; do
+  # Retrieve all audio track numbers
+  audio_tracks=$(echo "$tracks_json" |
+    jq -r '.tracks[] |
+      select(.type == "audio") |
+      (.id + 1)')
+
+  # Retrieve all subtitle track numbers
+  subtitle_tracks=$(echo "$tracks_json" |
+    jq -r '.tracks[] |
+      select(.type == "subtitles") |
+      (.id + 1)')
+
+  if [ -n "$audio_tracks" ]; then
+    for id in $audio_tracks; do
       mkvpropedit "$file" \
         --edit track:$id \
-        --set name="Tamil" \
-        --set language=tam \
-        --set languageIETF=ta
+        --set name="$track_name" \
+        --set language=$lang \
+        --set language-ietf=$lang_ietf
     done
+  fi
+
+  if [ -n "$subtitle_tracks" ]; then
+    for id in $subtitle_tracks; do
+      mkvpropedit "$file" \
+        --edit track:$id \
+        --set name="English" \
+        --set language=eng \
+        --set language-ietf=en
+    done
+  fi
+
+  if [ -n "$audio_tracks" ] || [ -n "$subtitle_tracks" ]; then
     echo "$(basename "$file")" >> "$processed_file"
   fi
 


### PR DESCRIPTION
## Summary
- add support for setting track language via flags like `--tamil`, `--hindi`, `--english`, `--telugu`, `--malayalam` or `--custom`
- update script to change all audio tracks to the chosen language
- force all subtitle tracks to English
- document `mkv_lang_switch.sh` usage in README

## Testing
- `mkvmerge --version` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*
- `bash mkv_lang_switch.sh /tmp --tamil`

------
https://chatgpt.com/codex/tasks/task_e_6889dda0da608329b380cb0792d4dcd1